### PR TITLE
Use a constant modification timestamp when calling `go-bindata(1)`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 RELEASE_DATE?=2018-02-28T23:59:59Z
+RELEASE_EPOCH_TIME?=1519862399
 GOPATH?=`go env GOPATH`
 
 # NOTES:
@@ -70,6 +71,7 @@ generate:
 	cd db/migrations && \
 		$(GOPATH)/bin/go-bindata \
 			-o bindata.go \
+			-modtime $(RELEASE_EPOCH_TIME) \
 			-pkg migrations \
 			-ignore '(~|\.bak)$$' \
 			-prefix crdb crdb/

--- a/db/migrations/bindata.go
+++ b/db/migrations/bindata.go
@@ -84,7 +84,7 @@ func _1517299952_initDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1517299952_init.down.sql", size: 786, mode: os.FileMode(420), modTime: time.Unix(1521137742, 0)}
+	info := bindataFileInfo{name: "1517299952_init.down.sql", size: 786, mode: os.FileMode(420), modTime: time.Unix(1519862399, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -104,7 +104,7 @@ func _1517299952_initUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1517299952_init.up.sql", size: 16035, mode: os.FileMode(420), modTime: time.Unix(1521137742, 0)}
+	info := bindataFileInfo{name: "1517299952_init.up.sql", size: 16035, mode: os.FileMode(420), modTime: time.Unix(1519862399, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
This removes the continual drift to `db/migrations/bindata.go`